### PR TITLE
Feat/airports

### DIFF
--- a/src/main/java/com/keyin/finalsprint/models/Airport.java
+++ b/src/main/java/com/keyin/finalsprint/models/Airport.java
@@ -1,0 +1,75 @@
+package com.keyin.finalsprint.models;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
+
+@Entity
+public class Airport {
+
+    @Id
+    @SequenceGenerator(name = "airport_sequence", sequenceName = "airport_sequence", allocationSize = 1)
+    @GeneratedValue(generator = "airport_sequence")
+    private long id;
+
+    private String code;
+    private String name;
+    private String city;
+    private String country;
+
+    public Airport() {
+
+    }
+
+    public Airport(String code, String name, String city, String country) {
+        this();
+        this.code = code;
+        this.name = name;
+        this.city = city;
+        this.country = country;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public void setCity(String city) {
+        this.city = city;
+    }
+
+    public String getCountry() {
+        return country;
+    }
+
+    public void setCountry(String country) {
+        this.country = country;
+    }
+
+    public record Updated(String code, String name, String city, String country) {
+
+        public boolean isFull() {
+            return code != null && name != null && city != null && country != null;
+        }
+    }
+}

--- a/src/main/java/com/keyin/finalsprint/repositories/AirportRepository.java
+++ b/src/main/java/com/keyin/finalsprint/repositories/AirportRepository.java
@@ -4,9 +4,12 @@ import com.keyin.finalsprint.models.Airport;
 import org.springframework.data.repository.ListCrudRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface AirportRepository extends ListCrudRepository<Airport, Long> {
     public Optional<Airport> findByCode(String code);
+
+    public List<Airport> findByNameContaining(String name);
 }

--- a/src/main/java/com/keyin/finalsprint/repositories/AirportRepository.java
+++ b/src/main/java/com/keyin/finalsprint/repositories/AirportRepository.java
@@ -1,0 +1,12 @@
+package com.keyin.finalsprint.repositories;
+
+import com.keyin.finalsprint.models.Airport;
+import org.springframework.data.repository.ListCrudRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface AirportRepository extends ListCrudRepository<Airport, Long> {
+    public Optional<Airport> findByCode(String code);
+}

--- a/src/main/java/com/keyin/finalsprint/routes/AirportController.java
+++ b/src/main/java/com/keyin/finalsprint/routes/AirportController.java
@@ -1,0 +1,46 @@
+package com.keyin.finalsprint.routes;
+
+import com.keyin.finalsprint.models.Airport;
+import com.keyin.finalsprint.services.AirportService;
+import com.keyin.finalsprint.utils.StatusCodes;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@CrossOrigin
+public class AirportController {
+
+    @Autowired
+    private AirportService service;
+
+    @PostMapping("airports/create")
+    public ResponseEntity<Airport> create(@RequestBody Airport.Updated body) {
+        if (!body.isFull()) return StatusCodes.badRequest();
+        Airport airport = service.addAirport(body);
+        if (airport == null) return StatusCodes.badRequest();
+        return ResponseEntity.ofNullable(airport);
+    }
+
+    @PostMapping("airports/{id}")
+    public ResponseEntity<Airport> update(@PathVariable Long id, @RequestBody Airport.Updated body) {
+        if (id == null) return StatusCodes.badRequest();
+        Airport airport = service.updateAirport(id, body);
+        if (airport == null) return StatusCodes.badRequest();
+        return ResponseEntity.ofNullable(airport);
+    }
+
+    @DeleteMapping("airports/{id}")
+    public ResponseEntity<Void> update(@PathVariable Long id) {
+        if (id == null) return StatusCodes.badRequest();
+        service.deleteAirport(id);
+        return StatusCodes.noContent();
+    }
+
+    @GetMapping("airports")
+    public ResponseEntity<List<Airport>> get() {
+        return ResponseEntity.ofNullable(service.get());
+    }
+}

--- a/src/main/java/com/keyin/finalsprint/routes/AirportController.java
+++ b/src/main/java/com/keyin/finalsprint/routes/AirportController.java
@@ -43,4 +43,9 @@ public class AirportController {
     public ResponseEntity<List<Airport>> get() {
         return ResponseEntity.ofNullable(service.get());
     }
+
+    @GetMapping("airports/search")
+    public ResponseEntity<List<Airport>> search(@RequestParam(required = false, name = "name") String name) {
+        return ResponseEntity.ofNullable(service.find(name));
+    }
 }

--- a/src/main/java/com/keyin/finalsprint/services/AirportService.java
+++ b/src/main/java/com/keyin/finalsprint/services/AirportService.java
@@ -1,0 +1,39 @@
+package com.keyin.finalsprint.services;
+
+import com.keyin.finalsprint.models.Airport;
+import com.keyin.finalsprint.repositories.AirportRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class AirportService {
+
+    @Autowired
+    private AirportRepository repository;
+
+    public Airport addAirport(Airport.Updated data) {
+        if (repository.findByCode(data.code()).isPresent()) return null;
+        Airport airport = new Airport(data.code(), data.name(), data.city(), data.country());
+        return repository.save(airport);
+    }
+
+    public Airport updateAirport(long id, Airport.Updated data) {
+        Airport airport = repository.findById(id).orElse(null);
+        if (airport == null) return null;
+        if (data.code() != null) airport.setCode(data.code());
+        if (data.name() != null) airport.setName(data.name());
+        if (data.city() != null) airport.setCity(data.city());
+        if (data.country() != null) airport.setCountry(data.country());
+        return repository.save(airport);
+    }
+
+    public void deleteAirport(long id) {
+        repository.deleteById(id);
+    }
+
+    public List<Airport> get() {
+        return repository.findAll();
+    }
+}

--- a/src/main/java/com/keyin/finalsprint/services/AirportService.java
+++ b/src/main/java/com/keyin/finalsprint/services/AirportService.java
@@ -36,4 +36,8 @@ public class AirportService {
     public List<Airport> get() {
         return repository.findAll();
     }
+
+    public List<Airport> find(String name) {
+        return repository.findByNameContaining(name);
+    }
 }


### PR DESCRIPTION
### What?

This adds the support for adding, removing, updating, and searching airports

It adds the following endpoints:
- `GET /airports` This returns a list of all airports
- `GET /airports/search?name=` This is a search endpoint that allows for searching by name.
- `POST /airports/create` This allows for creating and requires a body of code, name, city, and country.
- `POST /airports/{id}` This allows for updating a specific airport this can contain any or all of the same info used for creating.
- `DELETE /airports/{id}` This allows for the removal of an airport.