### PR TITLE
Add aircrafts

### DIFF
--- a/src/main/java/com/keyin/finalsprint/models/Aircraft.java
+++ b/src/main/java/com/keyin/finalsprint/models/Aircraft.java
@@ -1,0 +1,75 @@
+package com.keyin.finalsprint.models;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
+
+@Entity
+public class Aircraft {
+
+    @Id
+    @SequenceGenerator(name = "aircraft_sequence", sequenceName = "aircraft_sequence", allocationSize = 1)
+    @GeneratedValue(generator = "aircraft_sequence")
+    private long id;
+
+    private String registrationNumber;
+    private String manufacturer;
+    private String model;
+
+    private String airline;
+
+    public Aircraft() {
+
+    }
+
+    public Aircraft(String registrationNumber, String manufacturer, String model, String airline) {
+        this.registrationNumber = registrationNumber;
+        this.manufacturer = manufacturer;
+        this.model = model;
+        this.airline = airline;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public String getRegistrationNumber() {
+        return registrationNumber;
+    }
+
+    public void setRegistrationNumber(String registrationNumber) {
+        this.registrationNumber = registrationNumber;
+    }
+
+    public String getManufacturer() {
+        return manufacturer;
+    }
+
+    public void setManufacturer(String manufacturer) {
+        this.manufacturer = manufacturer;
+    }
+
+    public String getModel() {
+        return model;
+    }
+
+    public void setModel(String model) {
+        this.model = model;
+    }
+
+    public String getAirline() {
+        return airline;
+    }
+
+    public void setAirline(String airline) {
+        this.airline = airline;
+    }
+
+    public record Updated(String registrationNumber, String manufacturer, String model, String airline) {
+
+        public boolean isFull() {
+            return registrationNumber != null && manufacturer != null && model != null && airline != null;
+        }
+    }
+}

--- a/src/main/java/com/keyin/finalsprint/repositories/AircraftRepository.java
+++ b/src/main/java/com/keyin/finalsprint/repositories/AircraftRepository.java
@@ -1,0 +1,13 @@
+package com.keyin.finalsprint.repositories;
+
+import com.keyin.finalsprint.models.Aircraft;
+import org.springframework.data.repository.ListCrudRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface AircraftRepository extends ListCrudRepository<Aircraft, Long> {
+
+    public List<Aircraft> findByAirline(String airline);
+}

--- a/src/main/java/com/keyin/finalsprint/routes/AircraftController.java
+++ b/src/main/java/com/keyin/finalsprint/routes/AircraftController.java
@@ -1,0 +1,52 @@
+package com.keyin.finalsprint.routes;
+
+import com.keyin.finalsprint.models.Aircraft;
+import com.keyin.finalsprint.services.AircraftService;
+import com.keyin.finalsprint.utils.StatusCodes;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@CrossOrigin
+public class AircraftController {
+
+    @Autowired
+    private AircraftService service;
+
+    @PostMapping("aircrafts/create")
+    public ResponseEntity<Aircraft> create(@RequestBody Aircraft.Updated body) {
+        if (!body.isFull()) return StatusCodes.badRequest();
+        Aircraft aircraft = service.add(body);
+        if (aircraft == null) return StatusCodes.badRequest();
+        return ResponseEntity.ofNullable(aircraft);
+    }
+
+    @PostMapping("aircrafts/{id}")
+    public ResponseEntity<Aircraft> update(@PathVariable Long id, @RequestBody Aircraft.Updated body) {
+        if (id == null) return StatusCodes.badRequest();
+        Aircraft aircraft = service.update(id, body);
+        if (aircraft == null) return StatusCodes.badRequest();
+        return ResponseEntity.ofNullable(aircraft);
+    }
+
+    @DeleteMapping("aircrafts/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        if (id == null) return StatusCodes.badRequest();
+        if (!service.delete(id)) return StatusCodes.badRequest();
+        return StatusCodes.noContent();
+    }
+
+    @GetMapping("aircrafts")
+    public ResponseEntity<List<Aircraft>> get() {
+        return ResponseEntity.ofNullable(service.get());
+    }
+
+    @GetMapping("aircrafts/search")
+    public ResponseEntity<List<Aircraft>> search(@RequestParam(required = false, name = "airline") String airline) {
+        return ResponseEntity.ofNullable(service.find(airline));
+    }
+
+}

--- a/src/main/java/com/keyin/finalsprint/services/AircraftService.java
+++ b/src/main/java/com/keyin/finalsprint/services/AircraftService.java
@@ -1,0 +1,44 @@
+package com.keyin.finalsprint.services;
+
+import com.keyin.finalsprint.models.Aircraft;
+import com.keyin.finalsprint.repositories.AircraftRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class AircraftService {
+
+    @Autowired
+    private AircraftRepository repository;
+
+    public Aircraft add(Aircraft.Updated data) {
+        Aircraft aircraft = new Aircraft(data.registrationNumber(), data.manufacturer(), data.model(), data.airline());
+        return repository.save(aircraft);
+    }
+
+    public Aircraft update(long id, Aircraft.Updated data) {
+        Aircraft aircraft = repository.findById(id).orElse(null);
+        if (aircraft == null) return null;
+        if (data.registrationNumber() != null) aircraft.setRegistrationNumber(data.registrationNumber());
+        if (data.manufacturer() != null) aircraft.setManufacturer(data.manufacturer());
+        if (data.model() != null) aircraft.setModel(data.model());
+        if (data.airline() != null) aircraft.setAirline(data.airline());
+        return repository.save(aircraft);
+    }
+
+    public boolean delete(long id) {
+        if (repository.findById(id).isEmpty()) return false;
+        repository.deleteById(id);
+        return true;
+    }
+
+    public List<Aircraft> get() {
+        return repository.findAll();
+    }
+
+    public List<Aircraft> find(String airline) {
+        return repository.findByAirline(airline);
+    }
+}


### PR DESCRIPTION
### What?

This adds the support for adding, removing, updating, and searching aircrafts

It adds the following endpoints:
- `GET /aircrafts` This returns a list of all aircrafts
- `GET /aircrafts/search?airline=` This is a search endpoint that allows for searching by airline.
- `POST /aircrafts/create` This allows for creating and requires a body of registrationNumber, manufactuerer, model, airline.
- `POST /aircrafts/{id}` This allows for updating a specific aircraft this can contain any or all of the same info used for creating.
- `DELETE /aircraft/{id}` This allows for the removal of an aircraft.